### PR TITLE
Improve World ID verification error feedback

### DIFF
--- a/client/src/components/WorldIDButton.tsx
+++ b/client/src/components/WorldIDButton.tsx
@@ -1,7 +1,8 @@
 import { useState, useEffect } from 'react';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
-import { Shield, Check } from 'lucide-react';
+import { Shield, Check, AlertTriangle } from 'lucide-react';
+import { Alert, AlertDescription } from '@/components/ui/alert';
 import { MiniKit, VerifyCommandInput, VerificationLevel, ISuccessResult } from '@worldcoin/minikit-js';
 
 interface WorldIDButtonProps {
@@ -13,6 +14,8 @@ interface WorldIDButtonProps {
 export default function WorldIDButton({ onVerify, isVerified = false, className = '' }: WorldIDButtonProps) {
   const [isVerifying, setIsVerifying] = useState(false);
   const [isMiniKitInstalled, setIsMiniKitInstalled] = useState(false);
+  const [statusMessage, setStatusMessage] = useState<string | null>(null);
+  const [failureReason, setFailureReason] = useState<string | null>(null);
 
   useEffect(() => {
     setIsMiniKitInstalled(MiniKit.isInstalled());
@@ -20,8 +23,10 @@ export default function WorldIDButton({ onVerify, isVerified = false, className 
 
   const handleVerify = async () => {
     console.log('World ID verification triggered');
+    setStatusMessage(null);
+    setFailureReason(null);
     setIsVerifying(true);
-    
+
     if (!isMiniKitInstalled) {
       console.log('MiniKit not installed, using fallback verification');
       // Fallback for development/testing
@@ -41,14 +46,18 @@ export default function WorldIDButton({ onVerify, isVerified = false, className 
 
       // World App will open verification drawer
       const { finalPayload } = await MiniKit.commandsAsync.verify(verifyPayload);
-      
+
       if (finalPayload.status === 'error') {
         console.log('Verification error:', finalPayload);
-        setIsVerifying(false);
+        setStatusMessage('Verification failed—try again in World App');
+        const errorDetails = (finalPayload as { error?: { code?: string; detail?: string; message?: string } }).error;
+        if (errorDetails) {
+          setFailureReason(errorDetails.detail || errorDetails.message || errorDetails.code || null);
+        }
         return;
       }
 
-      // Send proof to backend for verification  
+      // Send proof to backend for verification
       const verifyResponse = await fetch('/api/verify', {
         method: 'POST',
         headers: {
@@ -62,15 +71,27 @@ export default function WorldIDButton({ onVerify, isVerified = false, className 
       });
 
       const verifyResponseJson = await verifyResponse.json();
-      
-      if (verifyResponseJson.success) {
+
+      if (verifyResponse.ok && verifyResponseJson.success) {
         console.log('Verification success!');
         onVerify?.(true);
       } else {
         console.log('Backend verification failed:', verifyResponseJson.error);
+        setStatusMessage('Verification failed—try again in World App');
+        setFailureReason(
+          verifyResponseJson.error?.message ||
+            verifyResponseJson.error ||
+            (verifyResponse.ok ? 'Unknown verification error' : verifyResponse.statusText)
+        );
       }
     } catch (error) {
       console.error('World ID verification error:', error);
+      setStatusMessage('Verification failed—try again in World App');
+      if (error instanceof Error) {
+        setFailureReason(error.message);
+      } else {
+        setFailureReason('An unexpected error occurred during verification');
+      }
     } finally {
       setIsVerifying(false);
     }
@@ -86,14 +107,27 @@ export default function WorldIDButton({ onVerify, isVerified = false, className 
   }
 
   return (
-    <Button
-      onClick={handleVerify}
-      disabled={isVerifying}
-      className={className}
-      data-testid="button-world-id-verify"
-    >
-      <Shield className="w-4 h-4 mr-2" />
-      {isVerifying ? 'Verifying...' : 'Verify with World ID'}
-    </Button>
+    <div className="flex flex-col gap-2">
+      <Button
+        onClick={handleVerify}
+        disabled={isVerifying}
+        className={className}
+        data-testid="button-world-id-verify"
+      >
+        <Shield className="w-4 h-4 mr-2" />
+        {isVerifying
+          ? 'Verifying...'
+          : statusMessage || 'Verify with World ID'}
+      </Button>
+      {statusMessage && (
+        <Alert variant="destructive" className="flex items-start gap-2">
+          <AlertTriangle className="h-4 w-4 mt-0.5" />
+          <AlertDescription>
+            <p>{statusMessage}</p>
+            {failureReason && <p className="mt-1 text-muted-foreground">Details: {failureReason}</p>}
+          </AlertDescription>
+        </Alert>
+      )}
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- add inline destructive alert to World ID button and expose failure reason messages
- reset the verification button copy on failure while keeping it idle until the next retry
- retain successful verification flow while clearing prior error state on new attempts

## Testing
- npm run lint *(fails: next binary missing because dependencies are unavailable prior to install)*
- npm install *(fails: registry responded 403 for @eslint/eslintrc)*

------
https://chatgpt.com/codex/tasks/task_e_68cf154cf0288320bd6fd8b33b14ef3e