### PR TITLE
Add wouter dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "tw-animate-css": "^1.2.5",
     "vaul": "^1.1.2",
     "viem": "2.23.5",
+    "wouter": "^3.3.5",
     "zod": "^3.24.2",
     "zod-validation-error": "^3.4.0"
   },
@@ -82,6 +83,7 @@
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@types/wouter": "^3.0.2",
     "drizzle-kit": "^0.30.4",
     "eruda": "^3.4.1",
     "eslint": "^9",


### PR DESCRIPTION
## Summary
- add the wouter runtime dependency and TypeScript types to the root package manifest

## Testing
- npm install *(fails: registry access returns HTTP 403 via proxy)*
- npm run build *(fails: Next.js binaries missing because dependencies could not be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68cf1e9020ec83209409661f4a61740f