### PR TITLE
Add wouter dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,10 +73,12 @@
     "tw-animate-css": "^1.2.5",
     "vaul": "^1.1.2",
     "viem": "2.23.5",
+    "wouter": "^3.3.5",
     "zod": "^3.24.2",
     "zod-validation-error": "^3.4.0"
   },
   "devDependencies": {
+    "@types/wouter": "^3.0.2",
     "@eslint/eslintrc": "^3",
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",


### PR DESCRIPTION
## Summary
- add the `wouter` routing package and its type definitions to the project dependencies

## Testing
- npm install *(fails: 403 Forbidden when fetching @eslint/eslintrc from the npm registry)*
- npm run build *(fails: Next.js CLI not found because dependencies could not be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68cf227526fc83209fe42c360a3627e7