### PR TITLE
Add Next.js App wrapper for client providers

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,0 +1,20 @@
+import type { AppProps } from 'next/app';
+import type { Session } from 'next-auth';
+
+import ClientProviders from '@/providers';
+
+import '../client/src/index.css';
+
+type AppPageProps = {
+  session?: Session | null;
+};
+
+export default function App({ Component, pageProps }: AppProps<AppPageProps>) {
+  const { session = null, ...componentProps } = pageProps;
+
+  return (
+    <ClientProviders session={session}>
+      <Component {...componentProps} />
+    </ClientProviders>
+  );
+}


### PR DESCRIPTION
## Summary
- add a custom Next.js `_app` that wraps routed components in `ClientProviders`
- forward any `session` prop into the provider while keeping remaining props for the page
- pull in the current global stylesheet from the client bundle

## Testing
- `npm run lint` *(fails: dependency installation blocked by 403 from npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68cf4b3018c483209d046b8321e9e763