### PR TITLE
docs: update replit architecture guide

### DIFF
--- a/replit.md
+++ b/replit.md
@@ -1,6 +1,6 @@
 # Overview
 
-SAM Drip Crown Game is a World ID-verified king-of-the-hill style gaming application where verified humans compete to hold the "SAM Crown" and earn SAM tokens while maintaining possession. Built as a World App Mini App, the game implements competitive mechanics with a 1-hour cooldown system between steal attempts, sustainable token distribution, and real-time crown holder tracking. The application features a modern gaming UI with premium design elements, crown-themed components, and comprehensive leaderboard functionality.
+SAM Drip Crown Game is a World ID-verified king-of-the-hill style mini app built for World App. Players attempt to steal and hold the "SAM Crown" to earn tokens while respecting cooldowns, with all interactions verified through World ID. The UI follows World App guidelines and surfaces live crown stats, cooldown timers, and leaderboard data to keep competition engaging.
 
 # User Preferences
 
@@ -8,68 +8,51 @@ Preferred communication style: Simple, everyday language.
 
 # System Architecture
 
-## Frontend Architecture
-- **Framework**: React 18 with TypeScript and Vite for development/build tooling
-- **UI Library**: Radix UI primitives with shadcn/ui components for consistent, accessible interface elements
-- **Styling**: Tailwind CSS with custom gaming-focused design system featuring crown gold colors, dark/light mode support, and gaming aesthetics
-- **Font Strategy**: Inter for primary text and Orbitron for gaming elements (crown timer, competitive displays)
-- **State Management**: TanStack React Query for server state, React hooks for local state
-- **Routing**: Wouter for lightweight client-side routing
-- **Asset Management**: Custom crown icons, character images, and programmatic sound generation via Web Audio API
+## Next.js Application
+- **Framework**: Next.js 15 with TypeScript running in the `/pages` router. The root page lives at `pages/index.tsx` and renders the feature-rich experience exported from `client/src/pages/HomePage.tsx`.
+- **Routing**: Next.js handles routing and API endpoints. User-facing routes are generated from files in `pages/`, while server logic is exposed through `pages/api/*` handlers.
+- **Providers**: Global runtime context is defined in `src/providers/index.tsx`. `ClientProviders` wraps the tree with:
+  - `MiniKitProvider` for Mini App platform APIs.
+  - `SessionProvider` from `next-auth` for authentication state.
+  - A development-only `ErudaProvider` to debug in the in-app webview.
+- **Authentication**: `src/auth/index.ts` configures NextAuth to issue JWT sessions, and `middleware.ts` exports `auth` middleware so protected routes remain gated by session state.
+- **UI Toolkit**: Components under `src/components/` combine Tailwind CSS utilities with the Worldcoin Mini Apps UI Kit to stay consistent with the World App design language.
+- **World ID Actions**: MiniKit commands are triggered from client components such as `src/components/AuthButton`, which calls `MiniKit.commandsAsync.verify` and forwards proofs to server routes.
 
-## Backend Architecture  
-- **Runtime**: Node.js with Express server handling API routes and middleware
-- **Database**: PostgreSQL with Drizzle ORM for type-safe database interactions
-- **Session Management**: Express sessions with PostgreSQL store via connect-pg-simple
-- **Development Setup**: Vite middleware integration for hot module replacement and development server
+## API Layer
+- **Next API Routes**: Files under `pages/api/` (for example `pages/api/game.ts`) implement REST endpoints that orchestrate crown ownership, cooldown enforcement, and World ID proof verification.
+- **Shared Types**: Request and response contracts are validated with Zod schemas in `shared/`, keeping both client queries and server handlers type-safe.
+- **Persistence Abstractions**: The API routes rely on `server/storage.ts` for data access. Drizzle ORM (configured via `drizzle.config.ts`) maps PostgreSQL tables that track users, crown sessions, and token distributions.
 
-## Authentication & Verification
-- **World ID Integration**: @worldcoin/minikit-js for human verification and incognito actions
-- **Verification Flow**: Cloud-based verification with 'play-and-earn' action configured in World Developer Portal
-- **Mini App Environment**: Designed for World App with proper viewport and mobile optimizations
+## Styling & Assets
+- **Tailwind CSS**: Configured through `tailwind.config.ts` and `postcss.config.{js,mjs}` to provide the crown-themed visual system and animations.
+- **Fonts**: Gaming-inspired typography is loaded with Next fonts and custom CSS to highlight timers, leaderboard rankings, and the crown call-to-action.
+- **Assets**: Icons, sounds, and imagery live under `public/` and `client/src` utility folders so the Next.js asset pipeline can optimize them automatically.
 
-## Game Logic Components
-- **Crown Competition System**: King-of-the-hill mechanics with real-time crown holder tracking
-- **Cooldown System**: 1-hour steal attempt restrictions with progress indicators and timers
-- **Token Economics**: Sustainable distribution of 50k SAM tokens daily across active crown holders
-- **Real-time Updates**: Live timer displays for crown hold duration and earning calculations
-- **Leaderboard System**: Ranking by total crown time and tokens earned
+# Development Workflow
 
-## Data Schema
-- **Users Table**: Basic user management with UUID primary keys, username, and password fields
-- **Extensible Design**: Schema structured for future game-specific tables (crown holders, game sessions, token transactions)
+## Commands
+- `npm run dev` — Starts the Next.js development server on port 3000.
+- `npm run build` — Creates the optimized production build (`.next/`).
+- `npm run start` — Runs the compiled build locally (requires a prior `npm run build`).
+- `npm run lint` — Optional lint check powered by `next lint`.
 
-## Development Tooling
-- **TypeScript**: Strict type checking across shared schema, client, and server code
-- **Path Aliases**: Organized imports with @ for client components, @shared for common types
-- **Hot Reloading**: Vite development server with Express middleware integration
-- **Build Process**: Separate client (Vite) and server (esbuild) build pipelines
+## Environment Setup
+1. Copy `.env.example` to `.env.local` and populate World App, database, and NextAuth settings.
+2. Generate an `AUTH_SECRET` via `npx auth secret` and paste it into `.env.local`.
+3. If you use an HTTPS tunnel (e.g., ngrok), set `AUTH_URL` to the tunnel domain and list the domain in `allowedDevOrigins` inside `next.config.ts`.
+4. Install dependencies with `npm install`.
 
-# External Dependencies
+# MiniKit & World App Testing
 
-## World ID Services
-- **@worldcoin/minikit-js**: Mini App SDK for World ID verification and World App integration
-- **World Developer Portal**: Action configuration for 'play-and-earn' verification flows
-- **Cloud Verification**: Serverless human verification without requiring local World ID infrastructure
+1. Run `npm run dev` to start the local server.
+2. Expose port 3000 over HTTPS (e.g., `ngrok http 3000`) so World App can reach your environment.
+3. In the World App Developer Portal, point your Mini App action URL to the tunnel domain and ensure the action ID matches the value used in `src/components/AuthButton`.
+4. Launch World App, open the Mini App from the developer menu, and interact with the `Verify with World ID` button. Proofs are forwarded to `/api/verify`, which validates them against World ID cloud verification.
+5. Use the in-app experience to test crown stealing flows, cooldown behavior, and token calculations. The MiniKit provider and Eruda console help debug directly inside the World App webview.
 
-## Database Services
-- **@neondatabase/serverless**: PostgreSQL database provider with connection pooling
-- **Drizzle Kit**: Database migrations and schema management tooling
-- **WebSocket Support**: Required for Neon serverless connections via 'ws' package
+# Deployment
 
-## UI Framework Dependencies
-- **Radix UI**: Complete primitive component library for accessible interactions
-- **Tailwind CSS**: Utility-first styling with custom design tokens and gaming theme
-- **Lucide React**: Icon library for consistent gaming and UI iconography
-- **React Hook Form**: Form state management with validation via @hookform/resolvers
-
-## Development Dependencies
-- **Vite**: Frontend build tool with React plugin and development server
-- **ESBuild**: Fast server-side bundling for production deployments
-- **PostCSS**: CSS processing pipeline with Tailwind and Autoprefixer
-- **TypeScript**: Type checking and development experience enhancement
-
-## Deployment Integration
-- **Replit**: Development environment with runtime error overlay and cartographer plugins
-- **Vercel**: Production deployment target with environment variable management
-- **Environment Variables**: World App ID, Action ID, API keys, and database connection strings
+- **Vercel**: Ideal for production hosting; connect the repo, add environment variables, and Vercel will run `npm run build` automatically.
+- **Database**: Provision a PostgreSQL instance (e.g., Neon) and update environment variables so Drizzle migrations can run via `npm run db:push`.
+- **Monitoring**: Keep World App developer portal credentials and action configuration in sync with deployed URLs to avoid verification failures.


### PR DESCRIPTION
## Summary
- refresh replit.md to describe the current Next.js + MiniKit application architecture and supporting providers
- remove outdated Express/Vite references and outline the Next.js build commands
- document the updated steps for running dev/build scripts and testing MiniKit flows inside World App

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cf4b396a208320bc73da92ca15d2f0