### PR TITLE
Add wouter dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -121,7 +121,8 @@
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "tailwind-merge": "^3.2.0",
-        "viem": "2.23.5"
+        "viem": "2.23.5",
+        "wouter": "^3.3.5"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -129,6 +130,7 @@
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "@types/wouter": "^3.0.2",
         "eruda": "^3.4.1",
         "eslint": "^9",
         "eslint-config-next": "15.2.3",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "tailwindcss-animate": "^1.0.7",
     "tw-animate-css": "^1.2.5",
     "vaul": "^1.1.2",
+    "wouter": "^3.3.5",
     "viem": "2.23.5",
     "zod": "^3.24.2",
     "zod-validation-error": "^3.4.0"
@@ -82,6 +83,7 @@
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@types/wouter": "^3.0.2",
     "drizzle-kit": "^0.30.4",
     "eruda": "^3.4.1",
     "eslint": "^9",


### PR DESCRIPTION
## Summary
- add wouter runtime dependency to package.json to support routing needs
- include @types/wouter in dev dependencies for TypeScript hints and reflect the additions in package-lock

## Testing
- npm install *(fails: 403 Forbidden retrieving scoped packages from registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_68cf4b2e88008320b34ddc8017f405cc